### PR TITLE
Ft add column to sql expressions top select level

### DIFF
--- a/programs/query-parser/QueryParser.cpp
+++ b/programs/query-parser/QueryParser.cpp
@@ -95,7 +95,6 @@ std::string parseQuery(const std::string& query, const Args::Format& format) {
     return serialized_ast;
 }
 
-// --- Логика добавления колонки ---
 
 namespace DB
 {
@@ -114,12 +113,10 @@ static DB::ASTPtr parseSqlToAST(const std::string & sql)
     return parseQuery(parser, begin, end, "", 0, 0, 0);
 }
 
-// Парсит строку выражения (например "122 as insert_id") в AST узел
 static DB::ASTPtr parseExpressionToAST(const std::string & expr_str)
 {
     using namespace DB;
     
-    // Оборачиваем в SELECT
     std::string wrapped_query = "SELECT " + expr_str;
     
     ParserSelectQuery parser; 
@@ -200,7 +197,6 @@ static bool columnExists(const DB::ASTPtr & expression_list, const std::string &
 
 struct AddColumnParams {
     bool format_only = false;
-    // quote_identifier убран
     std::string column_name;
 };
 
@@ -248,7 +244,6 @@ static std::string addExtraColumnImpl(const std::string & sql, const AddColumnPa
 
     std::cerr << "[C++] Found " << selects.size() << " SELECT queries to modify." << std::endl;
 
-    // Извлекаем потенциальный алиас из строки column_name
     size_t as_pos = params.column_name.find(" as ");
     std::string potential_alias;
     if (as_pos != std::string::npos)
@@ -265,7 +260,6 @@ static std::string addExtraColumnImpl(const std::string & sql, const AddColumnPa
             {
                 std::cerr << "[C++] Adding column: " << params.column_name << std::endl;
                 
-                // ВСЕГДА парсим как выражение (поддержит и "id", и "122 as insert_id")
                 DB::ASTPtr new_col_node = parseExpressionToAST(params.column_name);
 
                 select_expression->children.push_back(new_col_node);
@@ -279,8 +273,6 @@ static std::string addExtraColumnImpl(const std::string & sql, const AddColumnPa
 
     return formatASTtoSQL(ast);
 }
-
-// --- Конец логики добавления колонки ---
 
 
 int mainEntryClickHouseQueryParser(int argc, char** argv) {
@@ -317,6 +309,7 @@ extern "C" {
         free(ast);
     }
 
+    // return values: ast_json, error_msg
     void __attribute__((visibility("default"))) chqp_2b52ae1fb9f4ec8c46b8c527df829c25_parse_query_v2(char* query, char** ast_json, char** error_msg) {
         std::string serialized_ast;
         try {

--- a/programs/query-parser/QueryParser.cpp
+++ b/programs/query-parser/QueryParser.cpp
@@ -128,7 +128,6 @@ static DB::ASTPtr parseExpressionToAST(const std::string & expr_str)
     if (!select_ast)
         throw Exception(DB::ErrorCodes::SYNTAX_ERROR, "Failed to parse expression: {}", expr_str);
         
-    // Извлекаем первый элемент из списка SELECT
     if (auto * select = dynamic_cast<DB::ASTSelectQuery *>(select_ast.get()))
     {
         DB::ASTPtr list = select->select();

--- a/programs/query-parser/QueryParser.cpp
+++ b/programs/query-parser/QueryParser.cpp
@@ -1,12 +1,28 @@
 #include <iostream>
 #include <string>
 #include <unordered_map>
+#include <vector>
+#include <set>
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <Parsers/ParserQuery.h>
+#include <Parsers/ParserSelectQuery.h>
 #include <Parsers/parseQuery.h>
+#include <Parsers/formatAST.h>
+#include <Parsers/IAST.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTWithAlias.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/Operators.h>
+#include <Common/Exception.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/JSON/Object.h>
 
 #include "JsonSerialization.hpp"
 #include "ASTSerialization.hpp"
@@ -79,6 +95,194 @@ std::string parseQuery(const std::string& query, const Args::Format& format) {
     return serialized_ast;
 }
 
+// --- Логика добавления колонки ---
+
+namespace DB
+{
+    namespace ErrorCodes
+    {
+        extern const int SYNTAX_ERROR;
+    }
+}
+
+static DB::ASTPtr parseSqlToAST(const std::string & sql)
+{
+    using namespace DB;
+    ParserQuery parser(sql.data() + sql.size(), false);
+    const char * begin = sql.data();
+    const char * end = sql.data() + sql.size();
+    return parseQuery(parser, begin, end, "", 0, 0, 0);
+}
+
+// Парсит строку выражения (например "122 as insert_id") в AST узел
+static DB::ASTPtr parseExpressionToAST(const std::string & expr_str)
+{
+    using namespace DB;
+    
+    // Оборачиваем в SELECT
+    std::string wrapped_query = "SELECT " + expr_str;
+    
+    ParserSelectQuery parser; 
+    const char * begin = wrapped_query.data();
+    const char * end = wrapped_query.data() + wrapped_query.size();
+    
+    DB::ASTPtr select_ast = parseQuery(parser, begin, end, "", 0, 0, 0);
+    
+    if (!select_ast)
+        throw Exception(DB::ErrorCodes::SYNTAX_ERROR, "Failed to parse expression: {}", expr_str);
+        
+    // Извлекаем первый элемент из списка SELECT
+    if (auto * select = dynamic_cast<DB::ASTSelectQuery *>(select_ast.get()))
+    {
+        DB::ASTPtr list = select->select();
+        if (list && !list->children.empty())
+        {
+            return list->children[0];
+        }
+    }
+    
+    throw Exception(DB::ErrorCodes::SYNTAX_ERROR, "Failed to extract expression from SELECT wrapper");
+}
+
+static std::string formatASTtoSQL(DB::ASTPtr ast)
+{
+    using namespace DB;
+    WriteBufferFromOwnString out;
+    formatAST(*ast, out, true, false);
+    out << ";";
+    out.finalize();
+    return out.str();
+}
+
+static void collectSelects(DB::ASTPtr node, std::vector<DB::ASTSelectQuery *> & out_selects)
+{
+    if (!node) return;
+    if (auto * union_select = dynamic_cast<DB::ASTSelectWithUnionQuery *>(node.get()))
+    {
+        auto list_of_selects = union_select->list_of_selects;
+        if (list_of_selects)
+        {
+            for (const auto & child : list_of_selects->children)
+            {
+                collectSelects(child, out_selects);
+            }
+        }
+    }
+    else if (auto * select = dynamic_cast<DB::ASTSelectQuery *>(node.get()))
+    {
+        out_selects.push_back(select);
+    }
+}
+
+static bool columnExists(const DB::ASTPtr & expression_list, const std::string & col_name, const std::string & alias_name)
+{
+    if (!expression_list) return false;
+    
+    for (const auto & child : expression_list->children)
+    {
+        std::string existing_alias = "";
+        if (auto * with_alias = dynamic_cast<DB::ASTWithAlias *>(child.get()))
+        {
+            existing_alias = with_alias->alias;
+        }
+        
+        std::string existing_name = "";
+        if (auto * identifier = dynamic_cast<DB::ASTIdentifier *>(child.get()))
+        {
+            existing_name = identifier->shortName();
+        }
+
+        if (!alias_name.empty() && existing_alias == alias_name) return true;
+        if (!col_name.empty() && existing_name == col_name) return true;
+    }
+    return false;
+}
+
+struct AddColumnParams {
+    bool format_only = false;
+    // quote_identifier убран
+    std::string column_name;
+};
+
+static AddColumnParams parseParams(const std::string & params_json_str)
+{
+    AddColumnParams params;
+    if (params_json_str.empty()) return params;
+
+    try {
+        Poco::JSON::Parser parser;
+        Poco::Dynamic::Var result = parser.parse(params_json_str);
+        Poco::JSON::Object::Ptr obj = result.extract<Poco::JSON::Object::Ptr>();
+
+        if (obj->has("format_only"))
+            params.format_only = obj->get("format_only").convert<bool>();
+
+        if (obj->has("column_name"))
+            params.column_name = obj->get("column_name").toString();
+
+    } catch (...) {
+    }
+    return params;
+}
+
+static std::string addExtraColumnImpl(const std::string & sql, const AddColumnParams & params)
+{
+    using namespace DB;
+
+    ASTPtr ast = parseSqlToAST(sql);
+    if (!ast)
+        throw Exception(DB::ErrorCodes::SYNTAX_ERROR, "Failed to parse SQL");
+
+    if (params.format_only)
+    {
+        return formatASTtoSQL(ast);
+    }
+
+    if (params.column_name.empty())
+    {
+        return formatASTtoSQL(ast);
+    }
+
+    std::vector<DB::ASTSelectQuery *> selects;
+    collectSelects(ast, selects);
+
+    std::cerr << "[C++] Found " << selects.size() << " SELECT queries to modify." << std::endl;
+
+    // Извлекаем потенциальный алиас из строки column_name
+    size_t as_pos = params.column_name.find(" as ");
+    std::string potential_alias;
+    if (as_pos != std::string::npos)
+    {
+        potential_alias = params.column_name.substr(as_pos + 4);
+    }
+
+    for (auto * select : selects)
+    {
+        ASTPtr select_expression = select->select();
+        if (select_expression)
+        {
+            if (!columnExists(select_expression, params.column_name, potential_alias))
+            {
+                std::cerr << "[C++] Adding column: " << params.column_name << std::endl;
+                
+                // ВСЕГДА парсим как выражение (поддержит и "id", и "122 as insert_id")
+                DB::ASTPtr new_col_node = parseExpressionToAST(params.column_name);
+
+                select_expression->children.push_back(new_col_node);
+            }
+            else
+            {
+                std::cerr << "[C++] Column " << params.column_name << " already exists, skipping." << std::endl;
+            }
+        }
+    }
+
+    return formatASTtoSQL(ast);
+}
+
+// --- Конец логики добавления колонки ---
+
+
 int mainEntryClickHouseQueryParser(int argc, char** argv) {
     using namespace DB;
 
@@ -113,7 +317,6 @@ extern "C" {
         free(ast);
     }
 
-    // return values: ast_json, error_msg
     void __attribute__((visibility("default"))) chqp_2b52ae1fb9f4ec8c46b8c527df829c25_parse_query_v2(char* query, char** ast_json, char** error_msg) {
         std::string serialized_ast;
         try {
@@ -135,5 +338,21 @@ extern "C" {
     
     void __attribute__((visibility("default"))) chqp_2b52ae1fb9f4ec8c46b8c527df829c25_free_error_v2(char* error_msg) {
         free(error_msg);
+    }
+
+    char* __attribute__((visibility("default"))) chqp_add_column_to_sql(char* sql, char* params_json) {
+        thread_local static std::vector<char> buffer;
+        
+        try {
+            AddColumnParams params = parseParams(std::string(params_json));
+            std::string result = addExtraColumnImpl(std::string(sql), params);
+            
+            buffer.resize(result.size() + 1);
+            std::memcpy(buffer.data(), result.c_str(), result.size() + 1);
+            
+            return buffer.data();
+        } catch (...) {
+            return nullptr;
+        }
     }
 }

--- a/programs/query-parser/QueryParser.cpp
+++ b/programs/query-parser/QueryParser.cpp
@@ -144,7 +144,7 @@ static std::string formatASTtoSQL(DB::ASTPtr ast)
 {
     using namespace DB;
     WriteBufferFromOwnString out;
-    formatAST(*ast, out, true, false);
+    formatAST(*ast, out, false, false);
     out << ";";
     out.finalize();
     return out.str();


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added support for adding a new column at the top level of SELECT queries and introduced formatting capabilities for SQL expressions.


- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.


### Documentation Update (docs.clickhouse.com)

#### Motivation:
The new feature allows users to add a new column at the top level of SELECT queries, providing greater flexibility in structuring SQL queries. Additionally, it introduces formatting capabilities for SQL expressions, making it easier to read and maintain complex queries.

