### PR TITLE
feat: detect plaintext password in remote/remoteSecure, extract CHYT …

### DIFF
--- a/programs/query-parser/QueryParser.cpp
+++ b/programs/query-parser/QueryParser.cpp
@@ -1,5 +1,7 @@
+#include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <fmt/format.h>
@@ -414,6 +416,189 @@ static std::string replaceSecretIdsImpl(const std::string & sql, const std::stri
     return formatASTtoSQL(ast);
 }
 
+static bool isSecretIdCall(const DB::ASTPtr & node)
+{
+    if (auto * func = dynamic_cast<DB::ASTFunction *>(node.get()))
+        return func->name == "$secret_id";
+    return false;
+}
+
+static bool isStringLiteral(const DB::ASTPtr & node)
+{
+    if (auto * literal = dynamic_cast<DB::ASTLiteral *>(node.get()))
+        return literal->value.getType() == DB::Field::Types::String;
+    return false;
+}
+
+static bool isPasswordArg(const DB::ASTPtr & node)
+{
+    return isStringLiteral(node) || isSecretIdCall(node);
+}
+
+static std::optional<size_t> getPasswordArgIndex(const DB::ASTFunction * func)
+{
+    if (!func->arguments)
+        return std::nullopt;
+
+    const auto & args = func->arguments->children;
+    if (args.empty())
+        return std::nullopt;
+
+    size_t arg_num = 1;
+
+    if (arg_num >= args.size())
+        return std::nullopt;
+
+    const auto & second_arg = args[arg_num];
+
+    if (auto * f = dynamic_cast<DB::ASTFunction *>(second_arg.get()))
+    {
+        if (f->name != "$secret_id")
+        {
+            arg_num = 2;
+        }
+        else
+        {
+            arg_num = 2;
+        }
+    }
+    else if (auto * literal = dynamic_cast<DB::ASTLiteral *>(second_arg.get()))
+    {
+        if (literal->value.getType() == DB::Field::Types::String)
+        {
+            std::string val = literal->value.safeGet<std::string>();
+            if (val.find('.') != std::string::npos)
+                arg_num = 2;
+            else
+                arg_num = 3;
+        }
+        else
+        {
+            arg_num = 2;
+        }
+    }
+    else
+    {
+        arg_num = 2;
+    }
+
+    if (arg_num >= args.size())
+        return std::nullopt;
+
+    const auto & user_arg = args[arg_num];
+    if (!isPasswordArg(user_arg))
+        return std::nullopt;
+
+    arg_num++;
+
+    if (arg_num >= args.size())
+        return std::nullopt;
+
+    const auto & password_arg = args[arg_num];
+    if (!isPasswordArg(password_arg))
+        return std::nullopt;
+
+    return arg_num;
+}
+
+static bool checkPlaintextPasswordInRemote(DB::ASTPtr node)
+{
+    if (!node) return false;
+
+    if (auto * func = dynamic_cast<DB::ASTFunction *>(node.get()))
+    {
+        if (func->name == "remote" || func->name == "remoteSecure")
+        {
+            auto password_idx = getPasswordArgIndex(func);
+            if (password_idx.has_value())
+            {
+                const auto & password_arg = func->arguments->children[*password_idx];
+                if (isStringLiteral(password_arg) && !isSecretIdCall(password_arg))
+                    return true;
+            }
+        }
+    }
+
+    for (const auto & child : node->children)
+    {
+        if (checkPlaintextPasswordInRemote(child))
+            return true;
+    }
+
+    return false;
+}
+
+static std::string hasPlaintextPasswordImpl(const std::string & sql)
+{
+    using namespace DB;
+
+    ASTPtr ast = parseSqlToAST(sql);
+    if (!ast)
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Failed to parse SQL");
+
+    bool result = checkPlaintextPasswordInRemote(ast);
+    return SerializeToJSON(result);
+}
+
+static bool isChytFunction(const std::string & name)
+{
+    static const std::unordered_set<std::string> chyt_functions = {
+        "concatYtTables",
+        "concatYtTablesRange",
+        "ytTable",
+        "ytTableRange",
+    };
+    return chyt_functions.contains(name);
+}
+
+static bool isChytMultiPathFunction(const std::string & name)
+{
+    return name == "concatYtTables";
+}
+
+static void collectChytPaths(DB::ASTPtr node, std::vector<std::string> & out_paths)
+{
+    if (!node) return;
+
+    if (auto * func = dynamic_cast<DB::ASTFunction *>(node.get()))
+    {
+        if (isChytFunction(func->name))
+        {
+            if (func->arguments)
+            {
+                const auto & args = func->arguments->children;
+                size_t end = isChytMultiPathFunction(func->name) ? args.size() : std::min(args.size(), size_t(1));
+                for (size_t i = 0; i < end; ++i)
+                {
+                    if (auto * literal = dynamic_cast<DB::ASTLiteral *>(args[i].get()))
+                    {
+                        if (literal->value.getType() == DB::Field::Types::String)
+                            out_paths.push_back(literal->value.safeGet<std::string>());
+                    }
+                }
+            }
+            return;
+        }
+    }
+
+    for (const auto & child : node->children)
+        collectChytPaths(child, out_paths);
+}
+
+static std::string extractChytTablePathsImpl(const std::string & sql)
+{
+    using namespace DB;
+
+    ASTPtr ast = parseSqlToAST(sql);
+    if (!ast)
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Failed to parse SQL");
+
+    std::vector<std::string> paths;
+    collectChytPaths(ast, paths);
+
+    return SerializeToJSON(paths);
+}
+
 
 int mainEntryClickHouseQueryParser(int argc, char** argv) {
     using namespace DB;
@@ -571,6 +756,60 @@ extern "C" {
     }
 
     void __attribute__((visibility("default"))) chqp_free_replace_secret_ids_error(char* error_msg) {
+        free(error_msg);
+    }
+
+    void __attribute__((visibility("default"))) chqp_has_plaintext_password_in_remote(char* sql, char** result_json, char** error_msg) {
+        *result_json = nullptr;
+        *error_msg = nullptr;
+        try {
+            std::string result = hasPlaintextPasswordImpl(std::string(sql));
+            *result_json = reinterpret_cast<char*>(malloc(result.size() + 1));
+            std::memcpy(*result_json, result.c_str(), result.size() + 1);
+        } catch (const std::exception& e) {
+            const char* msg = e.what();
+            size_t msg_len = strlen(msg);
+            *error_msg = reinterpret_cast<char*>(malloc(msg_len + 1));
+            std::memcpy(*error_msg, msg, msg_len + 1);
+        } catch (...) {
+            const char* msg = "Unknown error";
+            *error_msg = reinterpret_cast<char*>(malloc(strlen(msg) + 1));
+            std::memcpy(*error_msg, msg, strlen(msg) + 1);
+        }
+    }
+
+    void __attribute__((visibility("default"))) chqp_free_has_plaintext_password_result(char* result_json) {
+        free(result_json);
+    }
+
+    void __attribute__((visibility("default"))) chqp_free_has_plaintext_password_error(char* error_msg) {
+        free(error_msg);
+    }
+
+    void __attribute__((visibility("default"))) chqp_extract_chyt_table_paths(char* sql, char** result_json, char** error_msg) {
+        *result_json = nullptr;
+        *error_msg = nullptr;
+        try {
+            std::string result = extractChytTablePathsImpl(std::string(sql));
+            *result_json = reinterpret_cast<char*>(malloc(result.size() + 1));
+            std::memcpy(*result_json, result.c_str(), result.size() + 1);
+        } catch (const std::exception& e) {
+            const char* msg = e.what();
+            size_t msg_len = strlen(msg);
+            *error_msg = reinterpret_cast<char*>(malloc(msg_len + 1));
+            std::memcpy(*error_msg, msg, msg_len + 1);
+        } catch (...) {
+            const char* msg = "Unknown error";
+            *error_msg = reinterpret_cast<char*>(malloc(strlen(msg) + 1));
+            std::memcpy(*error_msg, msg, strlen(msg) + 1);
+        }
+    }
+
+    void __attribute__((visibility("default"))) chqp_free_extract_chyt_table_paths_result(char* result_json) {
+        free(result_json);
+    }
+
+    void __attribute__((visibility("default"))) chqp_free_extract_chyt_table_paths_error(char* error_msg) {
         free(error_msg);
     }
 }


### PR DESCRIPTION
…table paths

1. chqp_has_plaintext_password_in_remote(sql) -> bool Checks whether remote()/remoteSecure() contains a plaintext password instead of $secret_id. Supports both short and long forms:
   - remote(host, db.table, user, password) — password at arg index 3
   - remote(host, db, table, user, password) — password at arg index 4 The password position is determined by checking whether arg[1] contains a dot (db.table short form). Non-string-literal args after user are treated as sharding_key, not password.

2. chqp_extract_chyt_table_paths(sql) -> [string] Extracts YT table paths from CHYT table functions: concatYtTables, concatYtTablesRange, ytTable, ytTableRange. All string literal arguments are collected as paths.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
